### PR TITLE
Remove separate point validity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove `Copy` trait for `SecretKey` [#5]
+- Remove separate checks for point validity in `PublicKey` and `Signature` in favor of a singular `is_valid`
 
 ## [0.2.0] - 2024-02-28
 

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -97,24 +97,6 @@ impl PublicKey {
         Self(G2Affine::from_slice_unchecked(bytes))
     }
 
-    /// Returns true if the inner point is free of an $h$-torsion component, and
-    /// so it exists within the $q$-order subgroup $\mathbb{G}_2$. This
-    /// should always return true unless an "unchecked" API was used.
-    pub fn is_torsion_free(&self) -> bool {
-        self.0.is_torsion_free().into()
-    }
-
-    /// Returns true if the inner point is on the curve. This should always
-    /// return true unless an "unchecked" API was used.
-    pub fn is_on_curve(&self) -> bool {
-        self.0.is_on_curve().into()
-    }
-
-    /// Returns true if the inner point is the identity (the point at infinity).
-    pub fn is_identity(&self) -> bool {
-        self.0.is_identity().into()
-    }
-
     /// Returns true if the inner point is valid according to certain criteria.
     ///
     /// A [`PublicKey`] is considered valid if its inner point meets the
@@ -124,6 +106,9 @@ impl PublicKey {
     /// 2. It is on the curve.
     /// 3. It is not the identity.
     pub fn is_valid(&self) -> bool {
-        self.is_torsion_free() && self.is_on_curve() && !self.is_identity()
+        let is_identity: bool = self.0.is_identity().into();
+        self.0.is_torsion_free().into()
+            && self.0.is_on_curve().into()
+            && !is_identity
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -31,24 +31,6 @@ impl Signature {
         )
     }
 
-    /// Returns true if the inner point is free of an $h$-torsion component, and
-    /// so it exists within the $q$-order subgroup $\mathbb{G}_2$. This
-    /// should always return true unless an "unchecked" API was used.
-    pub fn is_torsion_free(&self) -> bool {
-        self.0.is_torsion_free().into()
-    }
-
-    /// Returns true if the inner point is on the curve. This should always
-    /// return true unless an "unchecked" API was used.
-    pub fn is_on_curve(&self) -> bool {
-        self.0.is_on_curve().into()
-    }
-
-    /// Returns true if the inner point is the identity (the point at infinity).
-    pub fn is_identity(&self) -> bool {
-        self.0.is_identity().into()
-    }
-
     /// Returns true if the inner point is valid according to certain criteria.
     ///
     /// A [`Signature`] is considered valid if its inner point meets the
@@ -58,7 +40,10 @@ impl Signature {
     /// 2. It is on the curve.
     /// 3. It is not the identity.
     pub fn is_valid(&self) -> bool {
-        self.is_torsion_free() && self.is_on_curve() && !self.is_identity()
+        let is_identity: bool = self.0.is_identity().into();
+        self.0.is_torsion_free().into()
+            && self.0.is_on_curve().into()
+            && !is_identity
     }
 }
 


### PR DESCRIPTION
There is no need to duplicate the separate checks for `is_identity`, `is_on_curve` and `is_torsion_free`. A singular `is_valid` should be enough.