### PR TITLE
Release `0.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-04-24
+
 ### Changed
 
 - Check validity of `PublicKey` and `Signature` points in signature verification [#7]
@@ -42,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/bls12_381-bls/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/bls12_381-bls/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls12_381-bls"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/bls12_381-bls"


### PR DESCRIPTION
## [0.3.0] - 2024-04-24

### Changed

- Check validity of `PublicKey` and `Signature` points in signature verification [#7]
- Check validity of `PublicKey` points when aggregating them [#8]

### Added

- Add `is_valid` check for `PublicKey` [#7]
- Add `Error::InvalidPoint` variant for invalid `PublicKey` and `Signature` points [#7]
- Add `Zeroize` trait for `SecretKey` [#5]

### Removed

- Remove `Copy` trait for `SecretKey` [#5]
- Remove separate checks for point validity in `PublicKey` and `Signature` in favor of a singular `is_valid`

[0.3.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.2.0...v0.3.0
