### PR TITLE
Fix the `parallel` feature

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -27,3 +27,9 @@ jobs:
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
       test_flags: --features=rkyv-impl,rkyv/size_16
+
+  test_parallel:
+    name: Nightly std tests parallel
+    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
+    with:
+      test_flags: --features=parallel,rkyv-impl,rkyv/size_16


### PR DESCRIPTION
With this PR we fix the compilation of the crate using the `parallel` feature, and while we're at it we return early on invalid keys. We also add the feature to the CI, so that it never happens again that compilation fails.