### PR TITLE
Release `0.3.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-06-27
+
+### Changed
+
+- Early return from `APK::aggregate` on invalid keys
+
+### Fixed
+
+- Fix compilation of with the `parallel` feature
+
 ## [0.3.0] - 2024-04-24
 
 ### Changed
@@ -44,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/bls12_381-bls/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/bls12_381-bls/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls12_381-bls"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/bls12_381-bls"


### PR DESCRIPTION
## [0.3.1] - 2024-06-27

### Changed

- Early return from `APK::aggregate` on invalid keys

### Fixed

- Fix compilation of with the `parallel` feature

[0.3.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.0...v0.3.1