### PR TITLE
Release version `0.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-08-01
+
 ### Added
 
 - Add `MultisigSignature` struct [#18]
@@ -72,7 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/bls12_381-bls/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls12_381-bls"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/bls12_381-bls"


### PR DESCRIPTION
## [0.4.0] - 2024-08-01

### Added

- Add `MultisigSignature` struct [#18]
- Add `Error::NoKeysProvided` variant [#18]

### Changed

- Rename `SecretKey::sign` to `sign_multisig` and change return to `MultisigSignature` [#18]
- Rename `SecretKey::sign_vulnerable` to `sign` [#18]
- Rename `APK` to `MultisigPublicKey` [#18]
- Change `APK::verify` to take a `MultisigSignature` [#18]

### Removed

- Remove `impl From<&PublicKey> for APK` [#18]
- Remove `impl From<&SecretKey> for APK` [#18]

[0.4.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.1...v0.4.0
