### PR TITLE
Release `0.4.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2024-12-17
+
 ### Added
 
 - Add serde `Serialize` and `Deserialize` implementations for `PublicKey`, `MultisigPublicKey`, `Signature`,
@@ -82,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/bls12_381-bls/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.2.0...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls12_381-bls"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/bls12_381-bls"


### PR DESCRIPTION
## [0.4.1] - 2024-12-17

### Added

- Add serde `Serialize` and `Deserialize` implementations for `PublicKey`, `MultisigPublicKey`, `Signature`,
`MultisigSignature` and `SecretKey` [#21]
- Add `serde`, `bs58` and `serde_json` optional dependencies [#21]
- Add `serde` feature [#21]

[0.4.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.0...v0.4.1
