### PR TITLE
Bump to version `0.5.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-02-10
+
 ### Changed
 
 - Update `dusk-bls12_381` to 0.14
@@ -88,7 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/bls12_381-bls/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.0...v0.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls12_381-bls"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/bls12_381-bls"


### PR DESCRIPTION
## [0.5.0](https://github.com/dusk-network/bls12_381-bls/compare/v0.4.1...v0.5.0) - 2024-02-10

### Changed

- Update `dusk-bls12_381` to 0.14