### PR TITLE
Remove Std Dependence & Check Serialized Output In Serde Tests

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -33,3 +33,12 @@ jobs:
     uses: dusk-network/.github/.github/workflows/run-tests.yml@main
     with:
       test_flags: --features=parallel,rkyv-impl,rkyv/size_16,serde
+
+  compiles_to_wasm_with_serde:
+    name: Compiles to wasm with serde enabled
+    runs-on: core
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dsherret/rust-toolchain-file@v1
+      - run: rustup target add wasm32-unknown-unknown
+      - run: cargo b --release --no-default-features --features serde --target wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Serde feature no longer has any std dependence [#3596]
+
 ## [0.5.0] - 2025-02-10
 
 ### Changed
@@ -82,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add initial commit, this package continues the development of [dusk-bls12_381-sign](https://github.com/dusk-network/bls12_381-sign/) at version `0.6.0` under the new name: `bls12_381-bls` and without the go related code.
 
 <!-- ISSUES -->
+[#3596]: https://github.com/dusk-network/rusk/issues/3596
 [#21]: https://github.com/dusk-network/bls12_381-bls/issues/21
 [#18]: https://github.com/dusk-network/bls12_381-bls/issues/18
 [#8]: https://github.com/dusk-network/bls12_381-bls/issues/8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ zeroize = { version = "1", default-features = false, features = ["derive"] }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 rayon = { version = "1.8", optional = true }
-serde = { version = "1.0", optional = true }
-bs58 = { version = "0.4" , optional = true }
-serde_json = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+bs58 = { version = "0.4" , default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.8"
+serde_json = "1.0"
 
 [features]
 rkyv-impl = [
@@ -37,4 +37,4 @@ rkyv-impl = [
     "bytecheck",
 ]
 parallel = ["dep:rayon"]
-serde = ["dep:serde", "bs58", "serde_json"]
+serde = ["serde/alloc", "bs58/alloc"]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -11,61 +11,96 @@ use bls12_381_bls::{
 };
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use serde::Serialize;
 
-#[test]
-fn public_key() {
-    let mut rng = StdRng::seed_from_u64(0xbeef);
-    let pk = PublicKey::from(&SecretKey::random(&mut rng));
-    let ser = serde_json::to_string(&pk);
-    let deser = serde_json::from_str(&ser.unwrap());
-    assert_eq!(pk, deser.unwrap());
+fn assert_canonical_json<T>(
+    input: &T,
+    expected: &str,
+) -> Result<String, Box<dyn std::error::Error>>
+where
+    T: ?Sized + Serialize,
+{
+    let serialized = serde_json::to_string(input)?;
+    let input_canonical: serde_json::Value = serialized.parse()?;
+    let expected_canonical: serde_json::Value = expected.parse()?;
+    assert_eq!(input_canonical, expected_canonical);
+    Ok(serialized)
 }
 
 #[test]
-fn multisig_public_key() {
+fn serde_public_key() -> Result<(), Box<dyn std::error::Error>> {
+    let mut rng = StdRng::seed_from_u64(0xbeef);
+    let pk = PublicKey::from(&SecretKey::random(&mut rng));
+    let ser = assert_canonical_json(
+        &pk,
+        "\"shUGhHy4u1NiQY8uzHpTDagQJEqYrDJuAfgjDUVK5uBxbNi2D4aeHmCVaLvebvR4SGv5tJqGsg1KLRmeJu9RH2ANVELqvDU4Tr2zVBkTot47d1Gpj7N7UUMB1QF4aY3Vd96\""
+    )?;
+    let deser: PublicKey = serde_json::from_str(&ser)?;
+    assert_eq!(pk, deser);
+    Ok(())
+}
+
+#[test]
+fn serde_multisig_public_key() -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = StdRng::seed_from_u64(0xbeef);
     let pk = MultisigPublicKey::aggregate(&[PublicKey::from(
         &SecretKey::random(&mut rng),
     )])
     .unwrap();
-    let ser = serde_json::to_string(&pk);
-    let deser = serde_json::from_str(&ser.unwrap());
-    assert_eq!(pk, deser.unwrap());
+    let ser = assert_canonical_json(
+        &pk,
+        "\"25kghHWDNorWmBuDUTfXvKseTHzDvDnAN6jSsP44ptZ7C1apiarwVqwJ4quxx3Yax5TicNXTZsauZVwjHbzFyvxZAjGMEGcPAhrvzji5mxaiF445mTep3g9BJFeTbtv9sDR3\""
+    )?;
+    let deser = serde_json::from_str(&ser)?;
+    assert_eq!(pk, deser);
+    Ok(())
 }
 
 #[test]
-fn signature() {
+fn serde_signature() -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = StdRng::seed_from_u64(0xbeef);
     let sk = SecretKey::random(&mut rng);
     let signature = sk.sign(b"a message");
-    let ser = serde_json::to_string(&signature).unwrap();
-    let deser = serde_json::from_str(&ser).unwrap();
+    let ser = assert_canonical_json(
+        &signature,
+        "\"6UxktyK2QmZA6PsB15iTAiwYns3QLBrZmsBJPR1smfp4MNU3CnoqKLRbiUS1h76HW9\""
+    )?;
+    let deser = serde_json::from_str(&ser)?;
     assert_eq!(signature, deser);
+    Ok(())
 }
 
 #[test]
-fn multisig_signature() {
+fn serde_multisig_signature() -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = StdRng::seed_from_u64(0xbeef);
     let sk = SecretKey::random(&mut rng);
     let pk = PublicKey::from(&sk);
     let signature = sk.sign_multisig(&pk, b"a message");
-    let ser = serde_json::to_string(&signature).unwrap();
-    let deser = serde_json::from_str(&ser).unwrap();
+    let ser = assert_canonical_json(
+        &signature,
+        "\"79PPAVxpdTbHhK81p5oTGkEqb6EVkAkxEb39emBdzffLHwyTnfSbN6AmAiv3SdZMci\""
+    )?;
+    let deser = serde_json::from_str(&ser)?;
     assert_eq!(signature, deser);
+    Ok(())
 }
 
 #[test]
-fn secret_key() {
+fn serde_secret_key() -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = StdRng::seed_from_u64(0xbeef);
     let sk = SecretKey::random(&mut rng);
-    let ser = serde_json::to_string(&sk).unwrap();
-    let deser = serde_json::from_str(&ser).unwrap();
+    let ser = assert_canonical_json(
+        &sk,
+        "\"J96A6LyxZL3JdymeEHL4bNhf5MmcmgSLkd6Umh5ELrPt\"",
+    )?;
+    let deser = serde_json::from_str(&ser)?;
     assert_eq!(sk, deser);
+    Ok(())
 }
 
 #[test]
-fn wrong_encoded() {
-    let wrong_encoded = "wrong-encoded";
+fn serde_wrong_encoded() {
+    let wrong_encoded = "\"wrong-encoded\"";
     let public_key: Result<PublicKey, _> = serde_json::from_str(&wrong_encoded);
     assert!(public_key.is_err());
 
@@ -85,7 +120,7 @@ fn wrong_encoded() {
 }
 
 #[test]
-fn too_long_encoded() {
+fn serde_too_long_encoded() {
     let length_33_enc = "\"yaujE5CNg7SRYuf3Vw7G8QQdM7267QxJtfqGUEjLbxyCC\"";
     let length_49_enc= "\"RCR6kPYZDuew8ovT9MoxVv7mKRsbygumf2UTjvzs6AJhnukLj3BiFvjaE45Q41tKqdA\"";
     let length_97_enc = "\"7a5RpCdtr1aaXvaR3AofnEnVRh7kpzyqE8eYJpCBVLKLLpXVeN9UrXGRTZyq2upTVaJT5QnPQwZCGXW1oxrEAzrPvQ4vbWFwiHMJijZMzrPsTjQJFju1H4shrajuqUG4fYFpC\"";
@@ -109,7 +144,7 @@ fn too_long_encoded() {
 }
 
 #[test]
-fn too_short_encoded() {
+fn serde_too_short_encoded() {
     let length_31_enc = "\"3uTp29S3e2HQBekFYvVwsmoeEzk4uVWwQUjvJPwWKwU\"";
     let length_47_enc =
         "\"2F3DDEDEuxrszs3JfzFq51tnGNm3ZtrHwa7sAA4pkeo1JkqGTEYudnBZLNAkCohAd\"";


### PR DESCRIPTION
https://github.com/dusk-network/rusk/issues/2773.

- Removes dependence on std for serde
- Change serde tests to check correctness of serialized output