### PR TITLE
Add dusk_bytes error trait implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `BadLength` trait implementation to `Error`
+- Add `InvalidChar` trait implementation to `Error`
+
 ### Changed
 
 - Serde feature no longer has any std dependence [#3596]

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,3 +43,15 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl dusk_bytes::BadLength for Error {
+    fn bad_length(found: usize, expected: usize) -> Self {
+        DuskBytesError::bad_length(found, expected).into()
+    }
+}
+
+impl dusk_bytes::InvalidChar for Error {
+    fn invalid_char(ch: char, index: usize) -> Self {
+        DuskBytesError::invalid_char(ch, index).into()
+    }
+}


### PR DESCRIPTION
This is required in order to parse hex directly using dusk_bytes

```rust

let signature = Signature::from_hex_str(sign.as_ref())

```