### PR TITLE
Bump to version `0.5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2025-08-08
+
 ### Added
 
 - Add `BadLength` trait implementation to `Error`
@@ -100,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#3]: https://github.com/dusk-network/bls12_381-bls/issues/3
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/bls12_381-bls/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/dusk-network/bls12_381-bls/compare/v0.3.1...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bls12_381-bls"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/dusk-network/bls12_381-bls"


### PR DESCRIPTION
## [0.5.1] - 2025-08-08

### Added

- Add `BadLength` trait implementation to `Error`
- Add `InvalidChar` trait implementation to `Error`

### Changed
- Serde feature no longer has any std dependence [#3596]

[0.5.1]: https://github.com/dusk-network/bls12_381-bls/compare/v0.5.0...v0.5.1
[#3596]: https://github.com/dusk-network/rusk/issues/3596
